### PR TITLE
Selinux contexts for files and directories

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -297,8 +297,16 @@ class postfix (
   exec { 'reload postfix local aliases':
     command     => "newaliases -oA${alias_maps}",
     refreshonly => true,
-    notify      => Class['postfix::service'],
+    notify      => [ File["${alias_maps}.db"], Class['postfix::service']],
     require     => [ Package[$postfix::params::package_name], Concat[$alias_maps] ],
+  }
+
+  file { "${alias_maps}.db":
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    selmode => 'etc_aliases_t',
   }
 
   concat { $alias_maps:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -306,7 +306,7 @@ class postfix (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    selmode => 'etc_aliases_t',
+    seltype => 'etc_aliases_t',
   }
 
   concat { $alias_maps:

--- a/manifests/vmail.pp
+++ b/manifests/vmail.pp
@@ -128,40 +128,6 @@ class postfix::vmail(
   }
 
   #
-  # sender login maps
-  #
-  #smtpd_sender_login_maps=hash:/etc/postfix/smtpd_sender_login_maps
-
-  concat::fragment{ '/etc/postfix/main.cf smtpd_sender_login_maps':
-    target  => '/etc/postfix/main.cf',
-    order   => '56',
-    content => "\n# virtual mailboxes\nsmtpd_sender_login_maps=hash:/etc/postfix/smtpd_sender_login_maps\n",
-  }
-
-  concat { "${postfix::params::baseconf}/smtpd_sender_login_maps":
-    ensure  => 'present',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    require => Package[$postfix::params::package_name],
-    notify  => Exec['reload postfix smtpd_sender_login_maps'],
-  }
-
-  exec { 'reload postfix smtpd_sender_login_maps':
-    command     => "postmap ${postfix::params::baseconf}/smtpd_sender_login_maps",
-    refreshonly => true,
-    notify      => Class['postfix::service'],
-    require     => [ Package[$postfix::params::package_name], Concat["${postfix::params::baseconf}/smtpd_sender_login_maps"] ],
-  }
-
-  concat::fragment{ '/etc/postfix/smtpd_sender_login_maps header':
-    target  => "${postfix::params::baseconf}/smtpd_sender_login_maps",
-    order   => '00',
-    content => template("${module_name}/vmail/mailbox/header.erb"),
-  }
-
-
-  #
   # virtual domains
   #
   #virtual_mailbox_domains=hash:/etc/postfix/vmail_domains

--- a/manifests/vmail/account.pp
+++ b/manifests/vmail/account.pp
@@ -24,12 +24,16 @@ define postfix::vmail::account(
   }
 
   file { "${postfix::vmail::mailbox_base}/${domain}/${accountname}":
-    ensure  => 'directory',
-    owner   => $postfix::postfix_username,
-    group   => $postfix::postfix_username,
-    mode    => '0770',
-    require => Exec["eyp-postfix mailbox ${accountname}@${domain}"],
-    before  => Class['postfix::service'],
+    ensure   => 'directory',
+    owner    => $postfix::postfix_username,
+    group    => $postfix::postfix_username,
+    mode     => '0770',
+    selrange => 's0',
+    selrole  => 'object_r',
+    seltype  => 'mail_spool_t',
+    seluser  => 'system_u',
+    require  => Exec["eyp-postfix mailbox ${accountname}@${domain}"],
+    before   => Class['postfix::service'],
   }
 
   concat::fragment{ "/etc/postfix/vmail_mailbox ${accountname} ${domain}":
@@ -47,12 +51,16 @@ define postfix::vmail::account(
     }
 
     file { "${postfix::vmail::mailbox_base}/${domain}":
-      ensure  => 'directory',
-      owner   => $postfix::postfix_username,
-      group   => $postfix::postfix_username,
-      mode    => '0770',
-      require => Exec["eyp-postfix mailbox ${accountname}@${domain}"],
-      before  => Class['postfix::service'],
+      ensure   => 'directory',
+      owner    => $postfix::postfix_username,
+      group    => $postfix::postfix_username,
+      mode     => '0770',
+      selrange => 's0',
+      selrole  => 'object_r',
+      seltype  => 'mail_spool_t',
+      seluser  => 'system_u',
+      require  => Exec["eyp-postfix mailbox ${accountname}@${domain}"],
+      before   => Class['postfix::service'],
     }
   }
 }


### PR DESCRIPTION
I've added in code to set the selinux contexts on the various files that require it when running in enforce mode.  If selinux is not enabled, these are ignored.

Without the contexts, the /etc/aliases.db file could not be read by postfix and the /var/vmail directory structure was not accessible through dovecot.

There is no requirement to have the selinux module as a dependency as we are using puppet built-in functionality.