### PR TITLE
Allow creation of instances from Hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,40 @@ postfix::instance { 'out_domain2':
 }
 ```
 
+```puppet
+class { 'postfix':
+  instances => {
+    'gsuite' => {
+      'type'    => 'unix',
+      'chroot'  => 'n',
+      'command' => 'smtp',
+      'opts'    => {
+        'smtp_sasl_auth_enable'      => 'yes',
+        'smtp_sasl_security_options' => 'noanonymous',
+        'smtp_sasl_password_maps'    => 'hash:/etc/postfix/sasl/sasl_passwd',
+        'smtp_tls_security_level'    => 'encrypt',
+        'smtp_tls_CAfile'            => '/etc/ssl/certs/ca-bundle.crt'
+       }
+    }
+  }
+}
+```
+
+From Hiera:
+```yaml
+postfix::instances:
+  'gsuite':
+    'type': 'unix'
+    'chroot': 'n'
+    'command': 'smtp'
+    'opts':
+      'smtp_sasl_auth_enable': 'yes'
+      'smtp_sasl_security_options': 'noanonymous'
+      'smtp_sasl_password_maps': 'hash:/etc/postfix/sasl/sasl_passwd'
+      'smtp_tls_security_level': 'encrypt'
+      'smtp_tls_CAfile': '/etc/ssl/certs/ca-bundle.crt'
+```
+
 blackhole domain or account (to be able to blackhole a domain it requires **postfix::vmail**):
 
 ```puppet

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,7 @@ class postfix (
                 $message_size_limit                  = undef, # @param message_size_limit The maximal size in bytes of a message, including envelope information. (default: undef)
                 $compatibility_level                 = $postfix::params::compatibility_level_default,
                 $mynetworks_style                    = 'subnet',
+                $instances                           = {}
               ) inherits postfix::params {
 
   Exec {
@@ -112,6 +113,8 @@ class postfix (
   }
 
   validate_re($home_mailbox, [ '^Maildir/$', '^Mailbox$', '^$' ], 'Not a supported home_mailbox - valid values: Mailbox, Maildir/ or empty string')
+
+  validate_hash($instances)
 
   user { $postfix_username:
     ensure  => 'present',
@@ -364,5 +367,7 @@ class postfix (
       add_default_smtpd_instance => $add_default_smtpd_instance,
       default_smtpd_args         => $smtpd_instance_args,
     }
+
+    create_resources('postfix::instance', $instances)
   }
 }


### PR DESCRIPTION
A set of changes which will allow to set up instances directly from Hiera.

My use case is that I can set up an instance which has all the SASL settings for relay via G Suite already enabled.

In the example, /etc/postfix/sasl/sasl_passwd contains a line like:
[smtp-relay.gmail.com]:587 user@gsuite.domain.com:appspecificpassword
