### PR TITLE
Allow adding custom configuration to main.cf

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,19 @@ Most variables are standard postfix variables, please refer to postfix documenta
  * setgid_group
  * (...)
 
+For any variables that aren't handled, you can add your own key-value pairs with **custom_config_main**
+```puppet
+class { 'postfix':
+  custom_config_main => {
+    'smtp_sasl_auth_enable'      => 'yes',
+    'smtp_sasl_security_options' => 'noanonymous',
+    'smtp_sasl_password_maps'    => 'hash:/etc/postfix/sasl/sasl_passwd',
+    'smtp_tls_security_level'    => 'encrypt',
+    'smtp_tls_CAfile'            => '/etc/ssl/certs/ca-bundle.crt'
+  }
+}
+```
+
 * **install_mailclient**: controls if a mail client should be installed (default: true)
 
 #### SSL certificates:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,7 @@ class postfix (
                 $message_size_limit                  = undef, # @param message_size_limit The maximal size in bytes of a message, including envelope information. (default: undef)
                 $compatibility_level                 = $postfix::params::compatibility_level_default,
                 $mynetworks_style                    = 'subnet',
+                $custom_config_main                  = {}
               ) inherits postfix::params {
 
   Exec {
@@ -112,6 +113,8 @@ class postfix (
   }
 
   validate_re($home_mailbox, [ '^Maildir/$', '^Mailbox$', '^$' ], 'Not a supported home_mailbox - valid values: Mailbox, Maildir/ or empty string')
+
+  validate_hash($custom_config_main)
 
   user { $postfix_username:
     ensure  => 'present',

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -799,3 +799,7 @@ append_dot_mydomain = <%= scope.function_bool2yesno([@append_dot_mydomain]) %>
 default_process_limit = <%= @default_process_limit %>
 smtpd_client_connection_count_limit = <%= @smtpd_client_connection_count_limit %>
 smtpd_client_connection_rate_limit = <%= @smtpd_client_connection_rate_limit %>
+
+<% @custom_config_main.map do |k,v| -%>
+<%= k %> = <%= v %>
+<% end -%>


### PR DESCRIPTION
Change which allows to set any key-value combo not explicitly handled already. Also allows to set it from Hiera.

I used this to add support to main.cf to set up secure relay via G Suite.